### PR TITLE
Bug#4 - Updated the regex to validate other invalid urls

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -12,7 +12,7 @@ from app.utils.nickname_gen import generate_nickname
 def validate_url(url: Optional[str]) -> Optional[str]:
     if url is None:
         return url
-    url_regex = r'^https?:\/\/[^\s/$.?#].[^\s]*$'
+    url_regex = r'^https?://(?:www\.)?[a-zA-Z0-9:?&=._/-]+\.[a-zA-z]{2,3}/?\/[a-zA-Z0-9-]+'
     if not re.match(url_regex, url):
         raise ValueError('Invalid URL format')
     return url

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -97,17 +97,23 @@ def test_user_base_nickname_invalid(nickname, user_base_data):
         UserBase(**user_base_data)
 
 # Parametrized tests for URL validation
-@pytest.mark.parametrize("url", ["http://valid.com/profile.jpg", "https://valid.com/profile.png", None])
+@pytest.mark.parametrize("url", ["http://valid.com/profile.jpg", "https://valid.com/profile.png", None,"https://www.valid.com/profile.png"])
 def test_user_base_url_valid(url, user_base_data):
     user_base_data["profile_picture_url"] = url
     user = UserBase(**user_base_data)
     assert user.profile_picture_url == url
 
-@pytest.mark.parametrize("url", ["ftp://invalid.com/profile.jpg", "http//invalid", "https//invalid"])
+@pytest.mark.parametrize("url", [
+    "ftp://invalid.com/profile.jpg",
+    "http//invalid",
+    "https//invalid",
+    "http://www.githubanca"
+])
 def test_user_base_url_invalid(url, user_base_data):
     user_base_data["profile_picture_url"] = url
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError) as exc_info:
         UserBase(**user_base_data)
+    assert "Invalid URL format" in str(exc_info.value)
 
 
 @pytest.mark.parametrize("password", ["SecurePassword123@"])


### PR DESCRIPTION
**Issue Description**

1. When creating a new user profile through the Swagger UI, the user is able to provide a profile picture URL in the format https://www.github/user. This URL format should be considered invalid, as it does not follow the expected structure of a valid URL.

**Steps to Reproduce**

- Open the Swagger UI.
- Create a new user profile.
- In the profile_picture_url field, enter the value https://www.github/student.
- Observe that the user profile is successfully created, despite the invalid URL format.

**Expected Behavior**

- When the user provides a profile picture URL in the format https://www.github/user, the application should raise a ValueError or a similar exception, indicating that the URL format is invalid.

**Actual Behavior**

- The application currently allows the creation of a user profile with an invalid URL format in the profile_picture_url field, without raising any exception.