### PR TITLE
Bug #6Updated the docker file to fix the docker image vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /myapp
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
-    && apt-get install -y libc-bin=2.36-9+deb12u6 \
+    && apt-get install -y libc-bin=2.36-9+deb12u7 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -30,7 +30,7 @@ RUN python -m venv /.venv \
 FROM python:3.12-slim-bookworm as final
 
 # Upgrade libc-bin in the final stage to ensure security patch is applied
-RUN apt-get update && apt-get install -y libc-bin=2.36-9+deb12u6 \
+RUN apt-get update && apt-get install -y libc-bin=2.36-9+deb12u7 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -20,6 +20,19 @@ async def test_create_user_with_valid_data(db_session, email_service):
     assert user is not None
     assert user.email == user_data["email"]
 
+async def test_create_user_invalid_data_image(db_session, email_service):
+    user_data = {
+        "nickname": generate_nickname(),
+        "email": "valid_user@example.com",
+        "password": "ValidPassword123!",
+        "role": UserRole.ADMIN.name,
+        "profile_picture_url" : "https://www.updated_email.com/image"
+    }
+    user = await UserService.create(db_session, user_data,email_service)
+    assert user is not None
+    assert user.email == user_data["email"]
+    assert hasattr(user,"profile_picture_url")
+
 # Test creating a user with invalid data
 async def test_create_user_with_invalid_data(db_session, email_service):
     user_data = {
@@ -67,6 +80,12 @@ async def test_update_user_valid_data(db_session, user):
     updated_user = await UserService.update(db_session, user.id, {"email": new_email})
     assert updated_user is not None
     assert updated_user.email == new_email
+
+async def test_update_user_invalid_data_image(db_session, user):
+    profile_picture_url = "https://www.updated_email.com/image"
+    updated_user = await UserService.update(db_session, user.id, {"profile_picture_url": profile_picture_url})
+    assert updated_user is not None
+    assert updated_user.profile_picture_url != profile_picture_url
 
 # Test updating a user with invalid data
 async def test_update_user_invalid_data(db_session, user):


### PR DESCRIPTION
There are two vulnerabilities, both related to the libc-bin package:

CVE-2024-33599:
Severity: High
Status: Fixed
Installed Version: 2.36-9+deb12u6
Fixed Version: 2.36-9+deb12u7
Description: This vulnerability is a stack-based buffer overflow in the netgroup cache of glibc.
libc6 (additional information provided):
It appears there is no specific CVE mentioned for this vulnerability.
Further details about this vulnerability are not provided in the snippet you provided.
To mitigate the vulnerability related to CVE-2024-33599, it's essential to update the libc-bin package to version 2.36-9+deb12u7 or later. Additionally, further investigation may be needed regarding the libc6 vulnerability to determine the appropriate actions.