### PR TITLE
Blocking unauthorized users from uploading image

### DIFF
--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -8,8 +8,22 @@ from sqlalchemy.future import select
 from app.models.user_model import User, UserRole
 from app.utils.security import verify_password
 
+from unittest.mock import AsyncMock, patch
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.dependencies import get_db
+
 @pytest.mark.asyncio
 async def test_user_creation(db_session, verified_user):
+    """Test that a user is correctly created and stored in the database."""
+    result = await db_session.execute(select(User).filter_by(email=verified_user.email))
+    stored_user = result.scalars().first()
+    assert stored_user is not None
+    assert stored_user.email == verified_user.email
+    assert verify_password("MySuperPassword$1234", stored_user.hashed_password)
+
+@pytest.mark.asyncio
+async def test_current_user_error(db_session, verified_user):
     """Test that a user is correctly created and stored in the database."""
     result = await db_session.execute(select(User).filter_by(email=verified_user.email))
     stored_user = result.scalars().first()
@@ -38,9 +52,15 @@ async def test_user_role(db_session, admin_user):
 
 @pytest.mark.asyncio
 async def test_bulk_user_creation_performance(db_session, users_with_same_role_50_users):
-    result = await db_session.execute(select(User).filter_by(role=UserRole.AUTHENTICATED))
-    users = result.scalars().all()
-    assert len(users) == 50
+    async with db_session.begin():
+        for user in users_with_same_role_50_users:
+            db_session.add(user)
+        await db_session.flush()
+
+    async with db_session.begin():
+        result = await db_session.execute(select(User).filter_by(role=UserRole.AUTHENTICATED))
+        users = result.scalars().all()
+        assert len(users) == 50
 
 @pytest.mark.asyncio
 async def test_password_hashing(user):

--- a/tests/test_image_uploader.py
+++ b/tests/test_image_uploader.py
@@ -23,7 +23,7 @@ def test_image():
 def test_file():
      image = Image.new('RGB', (500, 300), color='red')
      image.save('/tmp/test_image.jpg')
-     return UploadFile(filename="test_image.jpg", file=BytesIO(image.tobytes()))
+     return UploadFile(filename="test_image.jpg", file=BytesIO(image.tobytes()),size=12093)
 
 @pytest.fixture
 def test_user_id():


### PR DESCRIPTION
**Permission for Image Uploads:**

1. Description: Ensure that only Admin/Manager roles have permission to upload images to the mini for all other users.
2. Changes Made: Updated the upload functionality to restrict access based on user roles. Now, only Admin/Manager roles can upload images.
3. Impact: Enhances security by limiting image upload access to authorized personnel, preventing unauthorized users from uploading images.

**Duplicate Nicknames in Bulk User Creation:**

1. Description: Addressed an issue where bulk user creation was failing due to the creation of users with duplicate nicknames.
2. Changes Made: Implemented logic to prevent the creation of users with the same nickname during bulk user creation.
3. Impact: Improves the reliability and stability of bulk user creation, preventing potential errors and data inconsistencies caused by duplicate nicknames.